### PR TITLE
Add exclusion list feature for filtering messages and files

### DIFF
--- a/src/main/java/com/example/solace/ExclusionList.java
+++ b/src/main/java/com/example/solace/ExclusionList.java
@@ -1,0 +1,187 @@
+package com.example.solace;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility class for managing exclusion lists.
+ *
+ * Supports:
+ * - Exact string matching
+ * - Wildcard patterns (* and ?)
+ * - Regex patterns (lines starting with "regex:")
+ * - Comments (lines starting with #)
+ * - Empty lines are ignored
+ */
+public class ExclusionList {
+
+    private final Set<String> exactMatches = new HashSet<String>();
+    private final List<Pattern> regexPatterns = new ArrayList<Pattern>();
+    private final List<String> wildcardPatterns = new ArrayList<String>();
+
+    /**
+     * Load exclusion patterns from a file.
+     * Each line can be:
+     * - An exact string to match
+     * - A wildcard pattern using * (any chars) and ? (single char)
+     * - A regex pattern prefixed with "regex:"
+     * - A comment line starting with #
+     * - Empty lines are ignored
+     */
+    public static ExclusionList fromFile(File file) throws Exception {
+        ExclusionList list = new ExclusionList();
+
+        if (file == null || !file.exists()) {
+            return list;
+        }
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(file, StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                line = line.trim();
+
+                // Skip empty lines and comments
+                if (line.isEmpty() || line.startsWith("#")) {
+                    continue;
+                }
+
+                // Check for regex pattern
+                if (line.toLowerCase().startsWith("regex:")) {
+                    String pattern = line.substring(6).trim();
+                    list.regexPatterns.add(Pattern.compile(pattern));
+                }
+                // Check for wildcard pattern
+                else if (line.contains("*") || line.contains("?")) {
+                    list.wildcardPatterns.add(line);
+                }
+                // Exact match
+                else {
+                    list.exactMatches.add(line);
+                }
+            }
+        }
+
+        return list;
+    }
+
+    /**
+     * Check if a value should be excluded.
+     */
+    public boolean isExcluded(String value) {
+        if (value == null) {
+            return false;
+        }
+
+        // Check exact match
+        if (exactMatches.contains(value)) {
+            return true;
+        }
+
+        // Check wildcard patterns
+        for (String pattern : wildcardPatterns) {
+            if (matchesWildcard(value, pattern)) {
+                return true;
+            }
+        }
+
+        // Check regex patterns
+        for (Pattern pattern : regexPatterns) {
+            if (pattern.matcher(value).matches()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if content contains any excluded pattern.
+     */
+    public boolean containsExcluded(String content) {
+        if (content == null) {
+            return false;
+        }
+
+        // Check if content contains any exact match
+        for (String exact : exactMatches) {
+            if (content.contains(exact)) {
+                return true;
+            }
+        }
+
+        // Check regex patterns with find() for substring match
+        for (Pattern pattern : regexPatterns) {
+            if (pattern.matcher(content).find()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Simple wildcard matching.
+     * * matches any sequence of characters
+     * ? matches any single character
+     */
+    private boolean matchesWildcard(String value, String pattern) {
+        // Convert wildcard pattern to regex
+        StringBuilder regex = new StringBuilder();
+        for (int i = 0; i < pattern.length(); i++) {
+            char c = pattern.charAt(i);
+            switch (c) {
+                case '*':
+                    regex.append(".*");
+                    break;
+                case '?':
+                    regex.append(".");
+                    break;
+                case '.':
+                case '\\':
+                case '[':
+                case ']':
+                case '(':
+                case ')':
+                case '{':
+                case '}':
+                case '^':
+                case '$':
+                case '|':
+                case '+':
+                    regex.append("\\").append(c);
+                    break;
+                default:
+                    regex.append(c);
+            }
+        }
+        return value.matches(regex.toString());
+    }
+
+    /**
+     * Get count of loaded patterns.
+     */
+    public int size() {
+        return exactMatches.size() + wildcardPatterns.size() + regexPatterns.size();
+    }
+
+    /**
+     * Check if the exclusion list is empty.
+     */
+    public boolean isEmpty() {
+        return exactMatches.isEmpty() && wildcardPatterns.isEmpty() && regexPatterns.isEmpty();
+    }
+
+    @Override
+    public String toString() {
+        return "ExclusionList{exact=" + exactMatches.size() +
+               ", wildcard=" + wildcardPatterns.size() +
+               ", regex=" + regexPatterns.size() + "}";
+    }
+}

--- a/src/test/java/com/example/solace/ExclusionListTest.java
+++ b/src/test/java/com/example/solace/ExclusionListTest.java
@@ -1,0 +1,194 @@
+package com.example.solace;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for ExclusionList.
+ */
+public class ExclusionListTest {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Test
+    public void testExactMatch() throws Exception {
+        File excludeFile = tempFolder.newFile("exclude.txt");
+        String content = "exact-match-1\nexact-match-2\n";
+        Files.write(excludeFile.toPath(), content.getBytes(StandardCharsets.UTF_8));
+
+        ExclusionList list = ExclusionList.fromFile(excludeFile);
+
+        assertTrue(list.isExcluded("exact-match-1"));
+        assertTrue(list.isExcluded("exact-match-2"));
+        assertFalse(list.isExcluded("exact-match-3"));
+        assertFalse(list.isExcluded("exact-match")); // Partial won't match
+    }
+
+    @Test
+    public void testWildcardPattern() throws Exception {
+        File excludeFile = tempFolder.newFile("exclude.txt");
+        String content = "test-*.xml\norder_???.json\n";
+        Files.write(excludeFile.toPath(), content.getBytes(StandardCharsets.UTF_8));
+
+        ExclusionList list = ExclusionList.fromFile(excludeFile);
+
+        assertTrue(list.isExcluded("test-001.xml"));
+        assertTrue(list.isExcluded("test-abc.xml"));
+        assertTrue(list.isExcluded("test-.xml")); // * matches zero chars too
+        assertFalse(list.isExcluded("test-001.json"));
+
+        assertTrue(list.isExcluded("order_001.json"));
+        assertTrue(list.isExcluded("order_abc.json"));
+        assertFalse(list.isExcluded("order_1234.json")); // Too many chars for ???
+        assertFalse(list.isExcluded("order_12.json")); // Too few chars for ???
+    }
+
+    @Test
+    public void testRegexPattern() throws Exception {
+        File excludeFile = tempFolder.newFile("exclude.txt");
+        String content = "regex:^test-\\d{3}\\.xml$\nregex:order_[A-Z]+\\.json\n";
+        Files.write(excludeFile.toPath(), content.getBytes(StandardCharsets.UTF_8));
+
+        ExclusionList list = ExclusionList.fromFile(excludeFile);
+
+        assertTrue(list.isExcluded("test-001.xml"));
+        assertTrue(list.isExcluded("test-999.xml"));
+        assertFalse(list.isExcluded("test-abc.xml")); // Not digits
+        assertFalse(list.isExcluded("test-1234.xml")); // Too many digits
+
+        assertTrue(list.isExcluded("order_ABC.json"));
+        assertTrue(list.isExcluded("order_X.json"));
+        assertFalse(list.isExcluded("order_abc.json")); // Lowercase
+        assertFalse(list.isExcluded("order_123.json")); // Digits
+    }
+
+    @Test
+    public void testCommentsAndEmptyLines() throws Exception {
+        File excludeFile = tempFolder.newFile("exclude.txt");
+        String content = "# This is a comment\n\nexact-value\n# Another comment\npattern-*\n\n";
+        Files.write(excludeFile.toPath(), content.getBytes(StandardCharsets.UTF_8));
+
+        ExclusionList list = ExclusionList.fromFile(excludeFile);
+
+        assertEquals(2, list.size());
+        assertTrue(list.isExcluded("exact-value"));
+        assertTrue(list.isExcluded("pattern-test"));
+        assertFalse(list.isExcluded("# This is a comment"));
+    }
+
+    @Test
+    public void testContainsExcluded() throws Exception {
+        File excludeFile = tempFolder.newFile("exclude.txt");
+        String content = "secret-key\nregex:password=\\w+\n";
+        Files.write(excludeFile.toPath(), content.getBytes(StandardCharsets.UTF_8));
+
+        ExclusionList list = ExclusionList.fromFile(excludeFile);
+
+        assertTrue(list.containsExcluded("This contains secret-key in the middle"));
+        assertTrue(list.containsExcluded("config: password=abc123"));
+        assertFalse(list.containsExcluded("This has no exclusions"));
+    }
+
+    @Test
+    public void testEmptyList() throws Exception {
+        File excludeFile = tempFolder.newFile("exclude.txt");
+        String content = "# Only comments\n\n# Nothing else\n";
+        Files.write(excludeFile.toPath(), content.getBytes(StandardCharsets.UTF_8));
+
+        ExclusionList list = ExclusionList.fromFile(excludeFile);
+
+        assertTrue(list.isEmpty());
+        assertEquals(0, list.size());
+        assertFalse(list.isExcluded("anything"));
+        assertFalse(list.containsExcluded("anything"));
+    }
+
+    @Test
+    public void testNullFile() throws Exception {
+        ExclusionList list = ExclusionList.fromFile(null);
+
+        assertTrue(list.isEmpty());
+        assertFalse(list.isExcluded("anything"));
+    }
+
+    @Test
+    public void testNonExistentFile() throws Exception {
+        File nonExistent = new File(tempFolder.getRoot(), "does-not-exist.txt");
+        ExclusionList list = ExclusionList.fromFile(nonExistent);
+
+        assertTrue(list.isEmpty());
+    }
+
+    @Test
+    public void testNullValueChecks() throws Exception {
+        File excludeFile = tempFolder.newFile("exclude.txt");
+        String content = "test-value\n";
+        Files.write(excludeFile.toPath(), content.getBytes(StandardCharsets.UTF_8));
+
+        ExclusionList list = ExclusionList.fromFile(excludeFile);
+
+        assertFalse(list.isExcluded(null));
+        assertFalse(list.containsExcluded(null));
+    }
+
+    @Test
+    public void testMixedPatterns() throws Exception {
+        File excludeFile = tempFolder.newFile("exclude.txt");
+        String content = "exact-value\nwildcard-*\nregex:^pattern-\\d+$\n";
+        Files.write(excludeFile.toPath(), content.getBytes(StandardCharsets.UTF_8));
+
+        ExclusionList list = ExclusionList.fromFile(excludeFile);
+
+        assertEquals(3, list.size());
+
+        // Exact
+        assertTrue(list.isExcluded("exact-value"));
+        assertFalse(list.isExcluded("exact-values"));
+
+        // Wildcard
+        assertTrue(list.isExcluded("wildcard-test"));
+        assertTrue(list.isExcluded("wildcard-"));
+        assertFalse(list.isExcluded("wildcard"));
+
+        // Regex
+        assertTrue(list.isExcluded("pattern-123"));
+        assertFalse(list.isExcluded("pattern-abc"));
+    }
+
+    @Test
+    public void testSpecialRegexCharsInWildcard() throws Exception {
+        File excludeFile = tempFolder.newFile("exclude.txt");
+        // These contain regex special chars that should be escaped in wildcard mode
+        String content = "file.txt\npath[1].json\n(test).xml\n";
+        Files.write(excludeFile.toPath(), content.getBytes(StandardCharsets.UTF_8));
+
+        ExclusionList list = ExclusionList.fromFile(excludeFile);
+
+        assertTrue(list.isExcluded("file.txt"));
+        assertTrue(list.isExcluded("path[1].json"));
+        assertTrue(list.isExcluded("(test).xml"));
+        assertFalse(list.isExcluded("fileXtxt")); // . should not match any char
+    }
+
+    @Test
+    public void testToString() throws Exception {
+        File excludeFile = tempFolder.newFile("exclude.txt");
+        String content = "exact1\nexact2\nwild-*\nregex:test\n";
+        Files.write(excludeFile.toPath(), content.getBytes(StandardCharsets.UTF_8));
+
+        ExclusionList list = ExclusionList.fromFile(excludeFile);
+
+        String str = list.toString();
+        assertTrue(str.contains("exact=2"));
+        assertTrue(str.contains("wildcard=1"));
+        assertTrue(str.contains("regex=1"));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ExclusionList` utility class supporting flexible pattern matching
- Add `--exclude-file` option to 5 commands for filtering out unwanted items
- Add `--exclude-content` flag for content-based filtering where applicable
- Add comprehensive unit tests for ExclusionList functionality

## Features

The exclusion list file format supports:
- **Exact matching**: `exact-value`
- **Wildcard patterns**: `pattern-*.xml`, `file_???.json`
- **Regex patterns**: `regex:^test-\d{3}\.xml$`
- **Comments**: Lines starting with `#`
- Empty lines are ignored

## Commands Updated

| Command | Filters By | Content Flag |
|---------|------------|--------------|
| `consume` | Correlation ID | `--exclude-content` |
| `folder-publish` | Filename | `--exclude-content` |
| `oracle-publish` | Correlation ID + Content | N/A (always checks both) |
| `copy-queue` | Correlation ID | `--exclude-content` |
| `oracle-insert` | Filename | `--exclude-content` |

## Example Usage

```bash
# Create exclusion file
cat > exclude.txt << 'PATTERNS'
# Skip test messages
test-*
regex:^debug-\d+$
PATTERNS

# Use with consume command
solace-cli consume -H tcp://localhost:55555 -q myqueue --exclude-file exclude.txt --exclude-content
```

## Test plan

- [x] Unit tests for ExclusionList class (12 tests)
- [x] Verify compilation succeeds
- [x] Test exact match, wildcard, and regex patterns
- [x] Test comments and empty lines handling
- [x] Test null/empty file handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)