### PR TITLE
Add --key-password and --key-alias options for JKS/PKCS12 keystores

### DIFF
--- a/scripts/wizard.sh
+++ b/scripts/wizard.sh
@@ -27,6 +27,8 @@ WIZARD_TRUST_STORE=""
 WIZARD_TRUST_STORE_PASS=""
 WIZARD_KEY_STORE=""
 WIZARD_KEY_STORE_PASS=""
+WIZARD_KEY_PASSWORD=""
+WIZARD_KEY_ALIAS=""
 WIZARD_CLIENT_CERT=""
 WIZARD_CLIENT_KEY=""
 WIZARD_CA_CERT=""
@@ -192,6 +194,8 @@ setup_ssl() {
                     println_red "Warning: File not found: $WIZARD_KEY_STORE"
                 fi
                 prompt WIZARD_KEY_STORE_PASS "Key store password" "" "true"
+                prompt WIZARD_KEY_PASSWORD "Private key password (if different, press Enter to skip)" "" "true"
+                prompt WIZARD_KEY_ALIAS "Key alias (press Enter to use default)" ""
             fi
 
             echo ""
@@ -272,6 +276,8 @@ build_ssl_args() {
         if [[ -n "$WIZARD_KEY_STORE" ]]; then
             args="$args --key-store '$WIZARD_KEY_STORE'"
             [[ -n "$WIZARD_KEY_STORE_PASS" ]] && args="$args --key-store-password '$WIZARD_KEY_STORE_PASS'"
+            [[ -n "$WIZARD_KEY_PASSWORD" ]] && args="$args --key-password '$WIZARD_KEY_PASSWORD'"
+            [[ -n "$WIZARD_KEY_ALIAS" ]] && args="$args --key-alias '$WIZARD_KEY_ALIAS'"
         fi
 
         # Separate PEM files
@@ -1130,6 +1136,8 @@ wizard_orchestration() {
         orch_args="$orch_args --ssl"
         [[ -n "$WIZARD_KEY_STORE" ]] && orch_args="$orch_args --key-store '$WIZARD_KEY_STORE'"
         [[ -n "$WIZARD_KEY_STORE_PASS" ]] && orch_args="$orch_args --key-store-password '$WIZARD_KEY_STORE_PASS'"
+        [[ -n "$WIZARD_KEY_PASSWORD" ]] && orch_args="$orch_args --key-password '$WIZARD_KEY_PASSWORD'"
+        [[ -n "$WIZARD_KEY_ALIAS" ]] && orch_args="$orch_args --key-alias '$WIZARD_KEY_ALIAS'"
         [[ -n "$WIZARD_TRUST_STORE" ]] && orch_args="$orch_args --trust-store '$WIZARD_TRUST_STORE'"
         [[ -n "$WIZARD_TRUST_STORE_PASS" ]] && orch_args="$orch_args --trust-store-password '$WIZARD_TRUST_STORE_PASS'"
         [[ -n "$WIZARD_CLIENT_CERT" ]] && orch_args="$orch_args --client-cert '$WIZARD_CLIENT_CERT'"
@@ -1289,6 +1297,8 @@ wizard_oracle_orchestration() {
         orch_args="$orch_args --ssl"
         [[ -n "$WIZARD_KEY_STORE" ]] && orch_args="$orch_args --key-store '$WIZARD_KEY_STORE'"
         [[ -n "$WIZARD_KEY_STORE_PASS" ]] && orch_args="$orch_args --key-store-password '$WIZARD_KEY_STORE_PASS'"
+        [[ -n "$WIZARD_KEY_PASSWORD" ]] && orch_args="$orch_args --key-password '$WIZARD_KEY_PASSWORD'"
+        [[ -n "$WIZARD_KEY_ALIAS" ]] && orch_args="$orch_args --key-alias '$WIZARD_KEY_ALIAS'"
         [[ -n "$WIZARD_TRUST_STORE" ]] && orch_args="$orch_args --trust-store '$WIZARD_TRUST_STORE'"
         [[ -n "$WIZARD_TRUST_STORE_PASS" ]] && orch_args="$orch_args --trust-store-password '$WIZARD_TRUST_STORE_PASS'"
         [[ -n "$WIZARD_CLIENT_CERT" ]] && orch_args="$orch_args --client-cert '$WIZARD_CLIENT_CERT'"
@@ -1380,6 +1390,8 @@ SSL/TLS OPTIONS
   --ssl                     Enable SSL/TLS connection
   --key-store PATH          Client keystore (JKS/PKCS12) for mTLS
   --key-store-password      Password for keystore
+  --key-password            Password for private key (if different from keystore)
+  --key-alias               Alias of private key entry in keystore
   --trust-store PATH        Trust store for server validation
   --trust-store-password    Password for trust store
   --client-cert PATH        Client certificate (PEM format)

--- a/src/main/java/com/example/solace/ConnectionOptions.java
+++ b/src/main/java/com/example/solace/ConnectionOptions.java
@@ -55,6 +55,16 @@ public class ConnectionOptions {
             arity = "0..1")
     String keyStorePassword;
 
+    @Option(names = {"--key-password"},
+            description = "Password for private key (if different from key store password)",
+            interactive = true,
+            arity = "0..1")
+    String keyPassword;
+
+    @Option(names = {"--key-alias"},
+            description = "Alias of the private key entry in the key store")
+    String keyAlias;
+
     @Option(names = {"--client-cert"},
             description = "Path to client certificate file (PEM format, use with --client-key)")
     String clientCert;

--- a/src/main/java/com/example/solace/SolaceConnection.java
+++ b/src/main/java/com/example/solace/SolaceConnection.java
@@ -74,6 +74,16 @@ public class SolaceConnection {
                     }
                 }
 
+                // Set private key password if different from key store password
+                if (options.keyPassword != null) {
+                    properties.setProperty(JCSMPProperties.SSL_PRIVATE_KEY_PASSWORD, options.keyPassword);
+                }
+
+                // Set private key alias if specified
+                if (options.keyAlias != null) {
+                    properties.setProperty(JCSMPProperties.SSL_PRIVATE_KEY_ALIAS, options.keyAlias);
+                }
+
                 // Set authentication scheme for client certificate
                 properties.setProperty(JCSMPProperties.AUTHENTICATION_SCHEME,
                     JCSMPProperties.AUTHENTICATION_SCHEME_CLIENT_CERTIFICATE);


### PR DESCRIPTION
## Summary
- Add `--key-password` option for specifying private key password when it differs from the keystore password
- Add `--key-alias` option for specifying which key entry to use in the keystore
- Update wizard.sh to prompt for these values when using JKS/PKCS12 format
- Fixes `UnrecoverableKeyException` errors when key password differs from keystore password

## Test plan
- [ ] Test with JKS keystore where key password equals keystore password (existing behavior)
- [ ] Test with JKS keystore where key password differs from keystore password
- [ ] Test with PKCS12 keystore with specified key alias
- [ ] Verify wizard prompts for key password and alias when using JKS/PKCS12 option