### PR TITLE
Add batch transform mode support to wizard Oracle orchestration

### DIFF
--- a/scripts/wizard.sh
+++ b/scripts/wizard.sh
@@ -1252,6 +1252,40 @@ wizard_oracle_orchestration() {
     local work_dir
     prompt work_dir "Working directory" "/tmp/solace-oracle-orchestration"
 
+    # Transform mode
+    echo ""
+    println_yellow "Transform Configuration:"
+    select_option "Transform mode:" \
+        "Single file (process files one at a time)" \
+        "Batch folder (process entire folder at once)"
+    local transform_choice=$?
+
+    local transform_mode="single"
+    local transform_script=""
+
+    case $transform_choice in
+        0)
+            transform_mode="single"
+            echo "Using single-file mode with transform_message() function"
+            ;;
+        1)
+            transform_mode="batch"
+            echo ""
+            if prompt_yes_no "Use external transform script?" "y"; then
+                prompt transform_script "Path to transform script" ""
+                if [[ -n "$transform_script" && ! -f "$transform_script" ]]; then
+                    println_red "Warning: Transform script not found: $transform_script"
+                    if ! prompt_yes_no "Continue anyway?" "n"; then
+                        wait_for_key
+                        return
+                    fi
+                fi
+            else
+                echo "Using built-in transform_folder() function"
+            fi
+            ;;
+    esac
+
     # Processing options
     local dry_run=false
     local verbose=false
@@ -1280,6 +1314,8 @@ wizard_oracle_orchestration() {
     display_cmd="$display_cmd -d $dest_queue -w $work_dir"
     [[ -n "$sql_query" ]] && display_cmd="$display_cmd --sql \"...\""
     [[ -n "$sql_file" ]] && display_cmd="$display_cmd --sql-file $sql_file"
+    [[ "$transform_mode" == "batch" ]] && display_cmd="$display_cmd --transform-mode batch"
+    [[ -n "$transform_script" ]] && display_cmd="$display_cmd --transform-script $transform_script"
     [[ "$keep_files" == "true" ]] && display_cmd="$display_cmd --no-cleanup"
     [[ "$verbose" == "true" ]] && display_cmd="$display_cmd --verbose"
     [[ "$dry_run" == "true" ]] && display_cmd="$display_cmd --dry-run"
@@ -1322,6 +1358,10 @@ wizard_oracle_orchestration() {
 
     orch_args="$orch_args -d $dest_queue"
     orch_args="$orch_args -w '$work_dir'"
+
+    # Transform args
+    [[ "$transform_mode" == "batch" ]] && orch_args="$orch_args --transform-mode batch"
+    [[ -n "$transform_script" ]] && orch_args="$orch_args --transform-script '$transform_script'"
 
     [[ "$keep_files" == "true" ]] && orch_args="$orch_args --no-cleanup"
     [[ "$verbose" == "true" ]] && orch_args="$orch_args --verbose"


### PR DESCRIPTION
## Summary
- Add transform mode selection menu to wizard Oracle orchestration
- Support external transform script configuration in wizard
- Display transform options in command preview

## Details
Updates `wizard_oracle_orchestration()` to expose the new batch transform functionality added in PR #37.

The wizard now prompts users to choose between:
- **Single file mode**: Process files one at a time using `transform_message()` (default)
- **Batch folder mode**: Process entire folder at once, with option to specify external transform script

When batch mode is selected, users can:
- Use the built-in `transform_folder()` placeholder function
- Specify an external transform script path

## Test plan
- [ ] Run wizard and select Oracle orchestration
- [ ] Test single file mode selection
- [ ] Test batch mode with built-in transform
- [ ] Test batch mode with external script path
- [ ] Verify command preview shows correct options

## Related
- Follows PR #37 (Add batch transform mode to orchestrate-oracle.sh)
- Issue #38