### PR TITLE
Document cron-based consumer and Oracle SQL file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ sequenceDiagram
     CLI-->>User: Complete
 ```
 
-### Oracle Insert Flow
+### Oracle Insert/Update Flow
 
 ```mermaid
 sequenceDiagram
@@ -193,7 +193,7 @@ sequenceDiagram
     participant FS as File System
     participant Oracle as Oracle DB
 
-    User->>CLI: oracle-insert --folder /path --table msgs
+    User->>CLI: oracle-insert --folder /path --sql-file update.sql
     CLI->>CLI: Parse arguments
     CLI->>FS: Scan directory for files
     FS-->>CLI: List of files
@@ -205,13 +205,13 @@ sequenceDiagram
     loop For each file
         CLI->>FS: Read file content
         FS-->>CLI: File bytes
-        CLI->>Oracle: INSERT INTO table
-        Oracle-->>CLI: Row inserted
+        CLI->>Oracle: Execute SQL (INSERT/UPDATE/DELETE)
+        Oracle-->>CLI: Row affected
     end
 
     CLI->>Oracle: Commit transaction
     CLI->>Oracle: Close connection
-    CLI-->>User: Inserted N records
+    CLI-->>User: Processed N records
 ```
 
 ### Consume Command Flow
@@ -390,7 +390,9 @@ graph LR
 - **Browse** queue messages non-destructively
 - **Oracle Integration** - Query Oracle database and publish result rows as messages
 - **Oracle Export** - Export Oracle query results to files for later publishing
+- **Oracle Insert/Update** - Execute SQL (INSERT, UPDATE, DELETE) against Oracle for each file in a folder
 - **Folder Publishing** - Batch publish messages from files in a directory
+- **Scheduled Consumption** - Cron-based queue consumer with SSL keystore support for RHEL
 - **Two-Step Workflow** - Export from Oracle to files, then publish to Solace
 - **Exclusion Lists** - Filter out unwanted messages or files using flexible pattern matching
 - **Audit Logging** - JSON-formatted audit trail of command execution with parameters and results
@@ -1021,9 +1023,9 @@ This manifest can be used by batch transformation scripts (Java or bash) to acce
 
 ---
 
-## Oracle Insert from Files
+## Oracle Insert/Update from Files
 
-Read files from a folder and insert their contents into an Oracle database table. This is useful for loading message files into Oracle for processing or archiving.
+Read files from a folder and execute SQL statements against an Oracle database for each file. Use `--table` for auto-generated INSERT, or `--sql-file` for custom SQL (INSERT, UPDATE, DELETE, etc.).
 
 ```bash
 # Basic usage - insert files into a table
@@ -1101,7 +1103,7 @@ java -jar target/solace-cli-1.0.0.jar oracle-insert \
 
 ### Custom SQL File Format
 
-For complex INSERT statements, use `--sql-file`. Use `?` for the content parameter and `??` for the filename:
+Use `--sql-file` for any DML statement. Use `?` for file content and `??` for filename (without extension):
 
 ```sql
 -- insert_order.sql
@@ -1111,6 +1113,14 @@ INSERT INTO orders (
     received_timestamp,
     status
 ) VALUES (?, ??, SYSDATE, 'PENDING')
+```
+
+```sql
+-- update_order.sql
+UPDATE orders SET
+    order_data = ?,
+    updated_timestamp = SYSDATE
+WHERE source_filename = ??
 ```
 
 ---
@@ -1786,6 +1796,52 @@ Exclusion Statistics:
   Avg check time:  16.06 μs/msg
   Total overhead:  16.06 ms
 ```
+
+---
+
+## Scheduled Queue Consumption (Cron)
+
+For unattended, scheduled consumption of Solace messages on RHEL servers, use `cron-consume.sh`. It consumes messages over SSL using a Java keystore and writes each message to a file.
+
+```bash
+# Copy and edit the config file
+cp scripts/cron-consume.conf.example ~/.solace-consume.conf
+chmod 600 ~/.solace-consume.conf
+vi ~/.solace-consume.conf
+
+# Test manually
+./scripts/cron-consume.sh run
+
+# Install cron job (validates file permissions first)
+./scripts/cron-consume.sh install
+
+# Check status and recent log
+./scripts/cron-consume.sh status
+
+# Remove cron job
+./scripts/cron-consume.sh uninstall
+```
+
+The config file holds all connection, SSL, and schedule settings:
+
+```bash
+SOLACE_HOST=tcps://broker.example.com:55443
+SOLACE_VPN=default
+SOLACE_USER=myuser
+SOLACE_PASS=mypassword
+SOLACE_QUEUE=my.queue
+OUTPUT_DIR=/home/myuser/solace-messages
+KEY_STORE=/home/myuser/.ssl/keystore.jks
+KEY_STORE_PASS=changeit
+KEY_ALIAS=mykey
+TRUST_STORE=/home/myuser/.ssl/keystore.jks
+TRUST_STORE_PASS=changeit
+CONSUME_TIMEOUT=30
+BROWSE_ONLY=false          # true for non-destructive reads
+CRON_SCHEDULE="*/5 * * * *"
+```
+
+On `install`, the script validates that the config, keystore, and truststore files are owned by and readable only to the current user. See `scripts/cron-consume.conf.example` for full documentation.
 
 ---
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -70,7 +70,7 @@ Enter choice:
 | **7) Performance test** | Run throughput and latency benchmarks |
 | **t) Test queue orchestration** | Run automated test suite for queue orchestration |
 | **o) Test Oracle orchestration** | Run automated test suite for Oracle orchestration |
-| **8) Oracle operations** | Database integration (publish, export, insert) |
+| **8) Oracle operations** | Database integration (publish, export, insert/update via SQL file) |
 | **9) Configure connection** | Change Solace host, VPN, credentials, and SSL/TLS settings |
 | **s) Queue setup** | Create/delete queues via SEMP API |
 
@@ -226,6 +226,8 @@ The wizard automatically:
 | Script | Description |
 |--------|-------------|
 | `wizard.sh` | **Interactive wizard** - guided menu-driven interface |
+| `cron-consume.sh` | **Cron consumer** - scheduled queue consumption over SSL (RHEL) |
+| `cron-consume.conf.example` | Sample config for cron-consume.sh |
 | `common.sh` | Shared configuration and helper functions (source this) |
 | `setup-solace.sh` | Create/delete queues via SEMP API |
 | `solace-docker.sh` | Start/stop local Solace broker Docker container |
@@ -383,13 +385,27 @@ Demonstrates queue operations:
 Demonstrates Oracle integration:
 - oracle-publish: Query → Publish
 - oracle-export: Query → Files
-- oracle-insert: Files → Table
-- SQL file support
+- oracle-insert: Files → Table (INSERT, UPDATE, DELETE via SQL file)
+- SQL file support with `?` (content) and `??` (filename) placeholders
 - Column mapping
 - Dry run mode
 - Two-step workflow
 
 **Note:** Requires Oracle database. Script shows command syntax.
+
+**SQL File for INSERT/UPDATE:**
+
+The `oracle-insert` command accepts a `--sql-file` option with any DML statement. Use `?` for file content and `??` for filename (without extension):
+
+```sql
+-- Insert example
+INSERT INTO my_table (data, name) VALUES (?, ??)
+
+-- Update example
+UPDATE my_table SET data = ? WHERE name = ??
+```
+
+The wizard (option 8 → "Files → SQL to Oracle") prompts for either a table name (auto-generates INSERT) or a SQL file path, and displays the file contents for confirmation before execution.
 
 ### examples-perf-test.sh
 
@@ -706,6 +722,87 @@ done
 ```
 
 Or use a Java transform JAR for better performance with large datasets (single JVM instance, manifest loaded once into memory).
+
+### cron-consume.sh
+
+Non-interactive script for scheduled Solace queue consumption over SSL using Java keystore. Designed for unattended execution on RHEL via cron.
+
+```bash
+# Run the consumer manually
+./cron-consume.sh run
+
+# Install cron entry for the current user
+./cron-consume.sh install
+
+# Remove cron entry
+./cron-consume.sh uninstall
+
+# Check cron status and recent log entries
+./cron-consume.sh status
+
+# Use a custom config file
+./cron-consume.sh run /path/to/my-config.conf
+```
+
+**Configuration:**
+
+Copy `cron-consume.conf.example` to `~/.solace-consume.conf` and edit:
+
+```bash
+# Solace connection
+SOLACE_HOST=tcps://broker.example.com:55443
+SOLACE_VPN=default
+SOLACE_USER=myuser
+SOLACE_PASS=mypassword
+SOLACE_QUEUE=my.queue
+
+# SSL / Java KeyStore
+# KEY_STORE and TRUST_STORE can point to the same JKS file when it
+# contains both the private key entry and trusted CA certificates.
+KEY_STORE=/home/myuser/.ssl/keystore.jks
+KEY_STORE_PASS=changeit
+KEY_ALIAS=mykey
+TRUST_STORE=/home/myuser/.ssl/keystore.jks
+TRUST_STORE_PASS=changeit
+
+# Output directory for consumed message files
+OUTPUT_DIR=/home/myuser/solace-messages
+
+# Consume behavior
+CONSUME_COUNT=0          # 0 = all available
+CONSUME_TIMEOUT=30       # seconds
+BROWSE_ONLY=false        # true = non-destructive read
+
+# Cron schedule (default: every 5 minutes)
+CRON_SCHEDULE="*/5 * * * *"
+
+# Optional: set JAVA_HOME for cron's minimal PATH
+# JAVA_HOME=/usr/lib/jvm/java-11-openjdk
+```
+
+**Security:**
+
+On `install`, the script validates file ownership and permissions:
+- Config file must be `600` (contains passwords)
+- Keystore and truststore must not be world-readable
+- All files must be owned by the current user
+
+```
+$ ./cron-consume.sh install
+Installing Solace consumer cron job...
+
+Checking file security...
+  Config file: OK (/home/myuser/.solace-consume.conf)
+  Key store:   OK (/home/myuser/.ssl/keystore.jks)
+  Trust store: same as key store
+All security checks passed.
+
+Cron entry installed:
+  */5 * * * * /opt/solace-cli/scripts/cron-consume.sh run /home/myuser/.solace-consume.conf # solace-consume-cron
+
+Log file: /home/myuser/.solace-consume.log
+Output:   /home/myuser/solace-messages
+```
 
 ### test-orchestration.sh
 


### PR DESCRIPTION
## Summary
- Document `cron-consume.sh` in both root README and scripts README with full config examples, security validation details, and sample install output
- Document Oracle `--sql-file` support for UPDATE/DELETE (not just INSERT), with `?`/`??` placeholder examples
- Update Oracle Insert flow diagram to show INSERT/UPDATE/DELETE capability
- Add scheduled consumption and Oracle insert/update to features list
- Update wizard Oracle menu description and script overview table

## Test plan
- [ ] Verify README.md renders correctly on GitHub (mermaid diagrams, code blocks, tables)
- [ ] Verify scripts/README.md renders correctly
- [ ] Confirm all new sections are linked/reachable from existing content